### PR TITLE
Added runOnInit function

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ module.exports.cron = {
     },
     start: true, // Start task immediately
     timezone: 'Ukraine/Kiev', // Custom timezone
-    context: undefined // Custom context for onTick callback
+    context: undefined, // Custom context for onTick callback
+    runOnInit: true // Will fire your onTick function as soon as the requisit initialization has happened.
   }
 };
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,8 @@ export default function (sails) {
             config[job].onComplete,
             typeof config[job].start === 'boolean' ? config[job].start : true,
             config[job].timezone,
-            config[job].context
+            config[job].context,
+            typeof config[job].runOnInit === 'boolean' ? config[job].runOnInit : true
           );
         });
       });

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ export default function (sails) {
             typeof config[job].start === 'boolean' ? config[job].start : true,
             config[job].timezone,
             config[job].context,
-            typeof config[job].runOnInit === 'boolean' ? config[job].runOnInit : true
+            typeof config[job].runOnInit === 'boolean' ? config[job].runOnInit : false
           );
         });
       });


### PR DESCRIPTION
Added the possibility to add the `runOnInit` property, to make sails run the task as soon as the requisit initialization has happened.

```javascript
module.exports.cron = {
  myJob: {
    schedule: '* * * * * *',
    onTick: function() {
      console.log('I am triggering when time is come');
    },
    onComplete: function() {
      console.log('I am triggering when job is complete');
    },
    start: true, // Start task immediately
    timezone: 'Ukraine/Kiev', // Custom timezone
    context: undefined, // Custom context for onTick callback
    runOnInit: true // Will fire your onTick function as soon as the requisit initialization has happened.
  }
};
```