### PR TITLE
Allow user to access cron's library context

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ module.exports = {
 };
 ```
 
+## Context
+
+There are three states for the context, i.e. this on onTick call. 
+
+1. **If you don't declare context:** this = sails
+2. **If you declare `context = null`:** this = original cron's library context. You still have access to sails from global variable.
+3. **If you declare `context = {<any_object>}`:** this = {any_object} (as we expect)
+
 ## License
 
 [MIT](./LICENSE)

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ module.exports = function (sails) {
             config[job].onComplete,
             typeof config[job].start === 'boolean' ? config[job].start : true,
             config[job].timezone,
-            config[job].context || sails,
+            config[job].hasOwnProperty('context') ? config[job].context : sails,
             typeof config[job].runOnInit === 'boolean' ? config[job].runOnInit : false
           );
         });


### PR DESCRIPTION
Without this, we can't access this.onComplete().
If you don't like this approach, you can also delete ` || sails`, but this chance can break legacy code that uses `this` instead of `sails`